### PR TITLE
Changed the composer autoloading to use the classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "autoload": {
-        "files": ["lib/SqlFormatter.php"]
+        "classmap": ["lib"]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Using the `files` type is requiring the file on each request,
even when it is not needed, instead of using the PHP autoloading.
