### PR TITLE
Fixed the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.2.x-dev"
         }
     }
 }


### PR DESCRIPTION
As 1.1.0 has been released, it does not make any sense to keep dev-master marked as bein 1.0.x-dev.
