### PR TITLE
Add the number type to the simple word logic

### DIFF
--- a/lib/SqlFormatter.php
+++ b/lib/SqlFormatter.php
@@ -145,7 +145,7 @@ class SqlFormatter
                 // "(word/whitespace/boundary)"
                 $next_token = self::getNextToken(substr($string, 1));
                 if (isset($string[strlen($next_token['token']) + 1]) && $string[strlen($next_token['token']) + 1] === ')') {
-                    if (in_array($next_token['type'], array('word', 'whitespace', 'boundary'))) {
+                    if (in_array($next_token['type'], array('word', 'whitespace', 'boundary', 'number'))) {
                         return array(
                             'token'=>'(' . $next_token['token'] . ')',
                             'type'=>'word'


### PR DESCRIPTION
This is useful when doing queries inside a CREATE TABLE.  I think it looks better to see VARCHAR(255) on the same line instead of broken out.
