### PR TITLE
Corrected class name pass for closures.

### DIFF
--- a/lib/SqlFormatter.php
+++ b/lib/SqlFormatter.php
@@ -179,15 +179,15 @@ class SqlFormatter
         if (self::$init) return;
 
         // Sort reserved word list from longest word to shortest
-        usort(self::$reserved, array('SqlFormatter', 'sortLength'));
+        usort(self::$reserved, array(__CLASS__, 'sortLength'));
 
         // Set up regular expressions
-        self::$regex_boundaries = '('.implode('|',array_map(array('SqlFormatter', 'quote_regex'),self::$boundaries)).')';
-        self::$regex_reserved = '('.implode('|',array_map(array('SqlFormatter', 'quote_regex'),self::$reserved)).')';
-        self::$regex_reserved_toplevel = str_replace(' ','\\s+','('.implode('|',array_map(array('SqlFormatter', 'quote_regex'),self::$reserved_toplevel)).')');
-        self::$regex_reserved_newline = str_replace(' ','\\s+','('.implode('|',array_map(array('SqlFormatter', 'quote_regex'),self::$reserved_newline)).')');
+        self::$regex_boundaries = '('.implode('|',array_map(array(__CLASS__, 'quote_regex'),self::$boundaries)).')';
+        self::$regex_reserved = '('.implode('|',array_map(array(__CLASS__, 'quote_regex'),self::$reserved)).')';
+        self::$regex_reserved_toplevel = str_replace(' ','\\s+','('.implode('|',array_map(array(__CLASS__, 'quote_regex'),self::$reserved_toplevel)).')');
+        self::$regex_reserved_newline = str_replace(' ','\\s+','('.implode('|',array_map(array(__CLASS__, 'quote_regex'),self::$reserved_newline)).')');
 
-        self::$regex_function = '('.implode('|',array_map(array('SqlFormatter', 'quote_regex'),self::$functions)).')';
+        self::$regex_function = '('.implode('|',array_map(array(__CLASS__, 'quote_regex'),self::$functions)).')';
 
         self::$init = true;
     }


### PR DESCRIPTION
This is a simple way to not break things when class is renamed or when code is in namespaced classes.
