### PR TITLE
Prevent warnings in highlightToken

### DIFF
--- a/lib/SqlFormatter.php
+++ b/lib/SqlFormatter.php
@@ -864,7 +864,11 @@ class SqlFormatter
         if (self::is_cli()) {
             $token = $token[self::TOKEN_VALUE];
         } else {
-            $token = @htmlentities($token[self::TOKEN_VALUE],ENT_COMPAT,'UTF-8');
+            if (defined('ENT_IGNORE')) {
+              $token = htmlentities($token[self::TOKEN_VALUE],ENT_COMPAT | ENT_IGNORE ,'UTF-8');
+            } else {
+              $token = htmlentities($token[self::TOKEN_VALUE],ENT_COMPAT,'UTF-8');
+            }
         }
 
         if ($type===self::TOKEN_TYPE_BOUNDARY) {

--- a/tests/SqlFormatterTest.php
+++ b/tests/SqlFormatterTest.php
@@ -25,6 +25,21 @@ class SqlFormatterTest extends PHPUnit_Framework_TestCase {
 	function testHighlight($sql, $html) {
 		$this->assertEquals(trim($html), trim(SqlFormatter::highlight($sql)));
 	}
+
+    function testHighlightBinary() {
+        $sql = 'SELECT "' . pack('H*', "ed180e98a47a45b3bdd304b798bc5797") . '" AS BINARY';
+
+        if (defined('ENT_IGNORE')) {
+            // this is what gets written as string
+            $binaryData = '&quot;' . pack('H*', "180e7a450457") . '&quot;';
+        } else {
+            $binaryData = '';
+        }
+
+        $html = '<pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> <span style="color: blue;">' . $binaryData . '</span> <span style="font-weight:bold;">AS</span> <span style="color: #333;">BINARY</span></pre>';
+
+        $this->assertEquals(trim($html), trim(SqlFormatter::highlight($sql)));
+    }
 	/**
 	 * @dataProvider highlightCliData
 	 */


### PR DESCRIPTION
We use binary tokens and this will lead to a warning generated by `htmlentities()` which in turn means that the SF2 profile won't display any queries formatted with this bundle.

If there's a better solution for this (seems pretty hacky), I am fine with it, too.
