### PR TITLE
Add hhvm (non-nightly) to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.5
   - 5.4
   - 5.3
+  - hhvm
   - hhvm-nightly
 
 script: phpunit --coverage-text


### PR DESCRIPTION
The HHVM fix facebook/hhvm#2071 which for utf-8 entities is was tagged
in HHVM 3.1.

Seems to be passing fine now: https://travis-ci.org/dave1010/sql-formatter/jobs/47245742
