### PR TITLE
Command line syntax highlighter: Adding in support for multiple queries.

### DIFF
--- a/bin/sql-formatter
+++ b/bin/sql-formatter
@@ -37,4 +37,14 @@ function hasColorSupport() {
 
 $highlight = hasColorSupport();
 
-echo SqlFormatter::format($sql, $highlight);
+$queries = SqlFormatter::splitQuery($sql);
+$i = 1;
+$multipleQueries = count($queries) > 1;
+foreach ($queries as $query) {
+    if ($multipleQueries) {
+        echo PHP_EOL;
+        echo '== Query #' . $i . ' ==' . PHP_EOL;
+    }
+    echo SqlFormatter::format($query, $highlight);
+    $i++;
+}


### PR DESCRIPTION
Hi, I found your command line very useful and I love that I can pipe SQL into it, for example:

    php app/console doctrine:schema:update --dump-sql | sql-formatter

However, when running commands that output multiple queries like the one above, the formatting looked a bit strange. I added some very simple code that breaks the queries and formats them separately. I hope you'll be fine with adding it to your repository.

Again, thanks for your powerful SQL highlighter.

Sam