### PR TITLE
add test for :pdoParams - complements #74

### DIFF
--- a/tests/clihighlight.html
+++ b/tests/clihighlight.html
@@ -805,6 +805,9 @@
   [36;1m@"weird variable name"[0m;[0m
 
 [37mSELECT[0m 
+  [36;1m:pdoParam[0m;[0m
+
+[37mSELECT[0m 
   [34;1m"no closing quote[0m
 
 [37mSELECT[0m 

--- a/tests/compress.html
+++ b/tests/compress.html
@@ -74,6 +74,8 @@ SELECT @ and b;
 
 SELECT @"weird variable name";
 
+SELECT :pdoParam;
+
 SELECT "no closing quote
 
 SELECT [sqlserver] FROM [escap[e]]d style];

--- a/tests/format-highlight.html
+++ b/tests/format-highlight.html
@@ -805,6 +805,9 @@
   <span style="color: orange;">@&quot;weird variable name&quot;</span><span >;</span></pre>
 
 <pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> 
+  <span style="color: orange;">:pdoParam</span><span >;</span></pre>
+
+<pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> 
   <span style="color: blue;">&quot;no closing quote</span></pre>
 
 <pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> 

--- a/tests/format.html
+++ b/tests/format.html
@@ -804,6 +804,9 @@ SELECT
   @"weird variable name";
 
 SELECT 
+  :pdoParam;
+
+SELECT 
   "no closing quote
 
 SELECT 

--- a/tests/highlight.html
+++ b/tests/highlight.html
@@ -258,6 +258,8 @@
 
 <pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> <span style="color: orange;">@&quot;weird variable name&quot;</span><span >;</span></pre>
 
+<pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> <span style="color: orange;">:pdoParam</span><span >;</span></pre>
+
 <pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> <span style="color: blue;">&quot;no closing quote</span></pre>
 
 <pre style="color: black; background-color: white;"><span style="font-weight:bold;">SELECT</span> <span style="color: purple;">[sqlserver]</span> <span style="font-weight:bold;">FROM</span> <span style="color: purple;">[escap[e]]d style]</span><span >;</span></pre>

--- a/tests/sql.sql
+++ b/tests/sql.sql
@@ -258,6 +258,8 @@ SELECT @ and b;
 
 SELECT @"weird variable name";
 
+SELECT :pdoParam;
+
 SELECT "no closing quote
 
 SELECT [sqlserver] FROM [escap[e]]d style];


### PR DESCRIPTION
Just had the issue with v1.2.17 and noticed there is no test for that, so I added one.

There are also positional parameters (?) which are not correctly highlighted, I think. (#333 instead of orange), but did not want to change this.