### PR TITLE
fixed formatting of double colon operator (used in postgresql and mssql)

### DIFF
--- a/lib/SqlFormatter.php
+++ b/lib/SqlFormatter.php
@@ -102,7 +102,7 @@ class SqlFormatter
     );
 
     // Punctuation that can be used as a boundary between other tokens
-    protected static $boundaries = array(',', ';',':', ')', '(', '.', '=', '<', '>', '+', '-', '*', '/', '!', '^', '%', '|', '&', '#');
+    protected static $boundaries = array(',', ';', '::', ':', ')', '(', '.', '=', '<', '>', '+', '-', '*', '/', '!', '^', '%', '|', '&', '#');
 
     // For HTML syntax highlighting
     // Styles applied to different token types


### PR DESCRIPTION
Double colon operator is used in postgresql for type casting, for example:

SELECT last_login::DATE FROM person WHERE login='foo';

Sql-formatter in its current version will add a space between the colons, which effectively broke the query into not being valid anymore.

Double colon is also used in mssql, but for other purposes.

Proposed fix prevents double colon to be separated by space.

I've tested the fix with phpunit (all OK) and against previous uses of a single colon (bind variable). All seems fine.