### PR TITLE
Better formating for DECLARE, SET and WITH

### DIFF
--- a/lib/SqlFormatter.php
+++ b/lib/SqlFormatter.php
@@ -58,17 +58,18 @@ class SqlFormatter
         'SQL_SMALL_RESULT', 'SQL_WARNINGS', 'SQL_CACHE', 'SQL_NO_CACHE', 'START', 'STARTING', 'STATUS', 'STOP', 'STORAGE',
         'STRAIGHT_JOIN', 'STRING', 'STRIPED', 'SUPER', 'TABLE', 'TABLES', 'TEMPORARY', 'TERMINATED', 'THEN', 'TO', 'TRAILING', 'TRANSACTIONAL', 'TRUE',
         'TRUNCATE', 'TYPE', 'TYPES', 'UNCOMMITTED', 'UNIQUE', 'UNLOCK', 'UNSIGNED', 'USAGE', 'USE', 'USING', 'VARIABLES',
-        'VIEW', 'WHEN', 'WITH', 'WORK', 'WRITE', 'YEAR_MONTH'
+        'VIEW', 'WHEN', 'WORK', 'WRITE', 'YEAR_MONTH'
     );
 
     // For SQL formatting
     // These keywords will all be on their own line
     protected static $reserved_toplevel = array(
-        'SELECT', 'FROM', 'WHERE', 'SET', 'ORDER BY', 'GROUP BY', 'LIMIT', 'DROP',
+        'SELECT', 'FROM', 'WHERE', 'ORDER BY', 'GROUP BY', 'LIMIT', 'DROP',
         'VALUES', 'UPDATE', 'HAVING', 'ADD', 'AFTER', 'ALTER TABLE', 'DELETE FROM', 'UNION ALL', 'UNION', 'EXCEPT', 'INTERSECT'
     );
 
     protected static $reserved_newline = array(
+        'SET', 'DECLARE', 'WITH',
         'LEFT OUTER JOIN', 'RIGHT OUTER JOIN', 'LEFT JOIN', 'RIGHT JOIN', 'OUTER JOIN', 'INNER JOIN', 'JOIN', 'XOR', 'OR', 'AND'
     );
 


### PR DESCRIPTION
Prevent this outcome:
    DECLARE @date_today DATE; 
    SET 
        @date_today = '2022-12-12'; DECLARE @date_weekago DATE; 
    SET 
        @date_weekago = '2022-12-05'; WITH duplicate AS (

With this outcome:
    DECLARE @date_today DATE; 
    SET @date_today = '2022-12-12'; 
    DECLARE @date_weekago DATE; 
    SET @date_weekago = '2022-12-05'; 
    WITH duplicate AS (


My DECLARE SET order is like this due dynamic content being added to the query.

Maybe this doesn't suit all cases, such as multiple set at same line, but WITH and DECLARE at new line seems a must to me

I also added @andig CROSS JOIN